### PR TITLE
feat:2819 Add redirection_time param to checkout request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ merge:
 	--skip-validate-spec
 
 update-readme:
-	make merge && rdme openapi _build/api.yaml --version=2.1.0  --key=${README_API_KEY}
+	make merge && rdme openapi _build/api.yaml --version=2.2.0  --key=${README_API_KEY}

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -9,7 +9,7 @@ info:
     name: MIT-LICENSE
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Femsa API
-  version: 2.1.0
+  version: 2.2.0
 servers:
 - description: Femsa main server
   url: https://api.digitalfemsa.io
@@ -10777,6 +10777,11 @@ components:
           description: This field represents the type of checkout
           example: Integration
           type: string
+        redirection_time:
+          description: Number of seconds to wait before redirecting to the success
+            or failure url
+          example: 60
+          type: integer
       required:
       - allowed_payment_methods
       title: order_checkout_request

--- a/api.yaml
+++ b/api.yaml
@@ -4,7 +4,7 @@ servers:
     description: Femsa main server
 info:
   description: Femsa sdk
-  version: 2.1.0
+  version: 2.2.0
   contact:
     name: Engineering Femsa
     url: https://github.com/digitalfemsa/openapi/issues

--- a/schemas/checkouts/checkout_request.yml
+++ b/schemas/checkouts/checkout_request.yml
@@ -30,3 +30,7 @@ properties:
     type: string
     description: "This field represents the type of checkout"
     example: "Integration"
+  redirection_time:
+    type: integer
+    description: "Number of seconds to wait before redirecting to the success or failure url"
+    example: 60


### PR DESCRIPTION
### Description
<!--- 
Provide a general summary of your changes.
- Why do we need this?
- What this PR resolve/improve/fix?
- Is it critical? 
-->
It was added the `redirection_time` param to the `Order Create` request for embedded checkout flows. Although this param was documented in the DevCenter [Checkout Redireccionado - Crear una order vacía con opciones de checkout](https://developers.digitalfemsa.io/docs/checkout-redireccionado#crear-una-order-vac%C3%ADa-con-opciones-de-checkout), it was not added in the `Checkout Request` [codebase](https://github.com/digitaltitransversal/openapi/blob/main/schemas/checkouts/checkout_request.yml).

### Type
- [ ] Critical
- [ ] Hot fix
- [ ] Bug fix
- [ ] Scan fix
- [X] New feature
- [ ] Refactor / Improvements
- [ ] Breaking change <!--- This PR breaks some contract. Describe where does it impact! -->